### PR TITLE
Increased EventEmitter.defaultMaxListeners

### DIFF
--- a/gulp/index.js
+++ b/gulp/index.js
@@ -1,6 +1,8 @@
 var gulp        = require('gulp');
 var runSequence = require('run-sequence');
 
+// Prevent errors caused by too many listeners in gulp-watch
+require('events').EventEmitter.defaultMaxListeners = 0;
 
 // configure default task
 gulp.task('default', ['serve']);


### PR DESCRIPTION
By default, the limit for listeners is set to 10 which causes issues with large projects. Setting it to 0 removes that limit.