### PR TITLE
Eslint rules enhancements (key-spacing, indent)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -54,7 +54,8 @@
 	  ],
 	  "no-trailing-spaces": [
 		  "warn"
-	  ]
+	  ],
+    "key-spacing": 1
   },
   "env": {
     "es6": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,10 @@
     ],
     "indent": [
       2,
-      "tab"
+      "tab",
+      {
+        "SwitchCase": 1
+      }
     ],
     "linebreak-style": [
       2,


### PR DESCRIPTION
Hi guys,
Here at VI Munich @davelosert, @SheepFromHeaven and I work on an internal project, using eslint rules defined in this repository, considering they are used within all other JavaScript projects at VI. Past weeks led us to understanding that our eslint rules needs a little enhancements.

#### 1. Indentation level for `case` clauses in `switch`
Eslint `switch` statements default indention rules makes a little confusion in source code readability, since a closing bracket feels like closes final `case` or `default` clause, not the initial `switch` statement itself. Especially with statements containing several clauses with 3+ lines of logic inside. Here's a demonstration of such a readability issue:  
```
switch (a) {
case 'a':
  // Some logic here…
  // Some more logic here…
  // 3rd line with logic here…
  break;
case 'b':
  // Some logic here…
  // Some more logic here…
  // 3rd line with logic here…
  break;
case 'c':
  // Some logic here…
  // Some more logic here…
  // 3rd line with logic here…
  break;
default:
  break;
}
```

To fix presented readbility issue, we wish to enforce consistent indention of `case` clauses with a tab with respect to `switch` statements, so it reads like this:
```
switch (a) {
  case 'a':
    break;
  case 'b':
    break;
}
```
Now it's much more obvious that last bracket really closes `switch` statement.

---
#### 2. Consistent spacing between keys and values in object 
Another rule we wish to address, is `key-spacing`, enforcing consistency in spacing between keys and values in object literal properties. Otherwise, programmers become too artistic with these kind of formations. Perhaps, because Christmas 🎄  is comming?
```
return {
  STATES:                                                                                       STATES,
  getStateForInstitution:                                                       getStateForInstitution,
  getStateOfInstitutionRegistration:                                 getStateOfInstitutionRegistration,
  getPendingInstitutionAffiliations:                                 getPendingInstitutionAffiliations,
  getPendingInstitutionRegistrations:                               getPendingInstitutionRegistrations,
  getAffiliatedInstitutionDetails:                                     getAffiliatedInstitutionDetails,
  isCurrentUserWaitingForInstitutionRegistration:       isCurrentUserWaitingForInstitutionRegistration,
  isCurrentUserWaitingForAffiliationWithInstitution: isCurrentUserWaitingForAffiliationWithInstitution,
  isCurrentUserAffiliatedWithInstitution:                       isCurrentUserAffiliatedWithInstitution
};
```
We're not claiming against readability for this rule, but more regarding consistency. Therefore, we propose to set eslint `key-spacing: 1`, but with a weak warning level.

> This changes to `.eslintrc` file in this PR won't force all current/past projects to adjust at all, they can use a previous version of rules. But for new JavaScript projects we're going to take `.eslintrc` file from this repo, would be awesome to have these two enhancements proposed.

Guys, please let me know how do you feel about this two enhancements proposed&zwnj;_!_

w/ @davelosert, @SheepFromHeaven