### PR TITLE
moved static resource paths from configuration.js to header

### DIFF
--- a/app/_mock/configuration.js
+++ b/app/_mock/configuration.js
@@ -5,10 +5,6 @@ global.configuration.data = global.configuration.data || {};
 //// global variables
 global.configuration.data.global = global.configuration.data.global || {};
 
-// conditional resource loader base and baseMap path
-global.configuration.data.staticResourcesBase = './resources/';
-global.configuration.data.staticResourcesContentRepoBase = './resources-content/';
-
 // breakpoints see: \app\resources\css\settings\_settings.scss
 //global.configuration.data.global.bpXSmall = 300;
 //global.configuration.data.global.bpSmall = 600;

--- a/app/_partials/includes/htmlhead.scripts.html
+++ b/app/_partials/includes/htmlhead.scripts.html
@@ -5,6 +5,7 @@
 	var global = global || {};
 	global.configuration = {data: {page: {},global: {}}};
 	global.configuration.data.staticResourcesBase = 'resources/';
+	global.configuration.data.staticResourcesContentRepoBase = 'resources-content/';
 </script>
 
 <!-- build:js(.tmp) resources/js/scripts.head.all.min.js  -->


### PR DESCRIPTION
Currently there are 2 places to configure the staticResourceBase, one of them is redundant.
To ensure there is a possibility to configure the bases site specific i moved them to the htmlhead.scripts.html.